### PR TITLE
ci(build): build binary artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,25 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=buildkit-${{ matrix.target }}
           cache-to: type=gha,mode=max,scope=buildkit-${{ matrix.target }}
+
+  binary:
+    name: Binary
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo install cross --locked
+      - run: cross build --target ${{ matrix.target }} --release
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: moco-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/moco

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v0-rust-${{ matrix.target }}
 
       - run: cargo install cross --locked
       - run: cross build --target ${{ matrix.target }} --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Adds building binary artifacts to the CI process. The following targets are built:

- `x86_64-unknown-linux-gnu`
- `x86_64-unknown-linux-musl`
- `aarch64-unknown-linux-gnu`
- `aarch64-unknown-linux-musl`
- `armv7-unknown-linux-gnueabihf`

Cross-compilation is done using the [`cross`](https://github.com/cross-rs/cross) tool. More targets can easily be supported in the future, as needed.