### PR TITLE
ci(lint): add clippy cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v0-rust-clippy
 
       - run: cargo clippy -- -D warnings
 


### PR DESCRIPTION
Add a caching step to the `cargo clippy` step to speed it up by ~2x, assuming no dependencies are changed.