### PR TITLE
ci(build): run cargo check prior to binary and docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,24 @@ on:  # yamllint disable-line rule:truthy
     tags: ['*.*.*']
 
 jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v0-rust-check
+
+      - run: cargo check
+
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    needs:
+      - check
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +73,8 @@ jobs:
   binary:
     name: Binary
     runs-on: ubuntu-latest
+    needs:
+      - check
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Check that compilation will most likely succeed before building docker images and individual binaries. This ensures that extra CI minutes are not spent on failing builds.

It also only extends the total CI time by ~10 seconds.